### PR TITLE
Do not override `1build.yaml` if already exists in --init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ optional arguments:
   -h, --help  Print this help message
   -l, --list  Show all available commands - from `1build.yaml` file
   -v, --version  Show version of 1build and exit
+  -i, --init     Create default `1build.yaml` configuration file
 ```
 
 ## Contributing

--- a/onebuild/init_command.py
+++ b/onebuild/init_command.py
@@ -1,3 +1,5 @@
+import os
+
 from onebuild.command import Command
 from onebuild.file_writer import write
 
@@ -12,7 +14,9 @@ class InitCommand(Command):
 
     def execute(self, arg_parser, arguments, build_file_name, command_name):
         if len(arguments) < 2:
-            raise ValueError(__project_name_not_found_error_message__())
+            print(__project_name_not_found_error_message__())
+        elif os.path.isfile("1build.yaml"):
+            print(__file_already_exists_message__())
         else:
             write("1build.yaml", "w", default_yaml_file(arguments[1]))
 
@@ -20,3 +24,7 @@ class InitCommand(Command):
 def __project_name_not_found_error_message__():
     return "The 'project name' parameter is missing with --init" \
            "\n\nusage: 1build --init project_name"
+
+
+def __file_already_exists_message__():
+    return "1build.yaml configuration file already exists."

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
-
+import sys
+from io import StringIO
 from unittest.mock import patch, MagicMock
 
 from onebuild.main import run
 
 
-def test_create_default_yaml_file():
+@patch('os.path.isfile')
+def test_create_default_yaml_file(mock_isfile):
     mock_file_writer = MagicMock()
+
+    mock_isfile.return_value = False
 
     with patch("onebuild.init_command.write",
                mock_file_writer,
@@ -24,3 +28,24 @@ def test_error_message_if_file_name_is_not_provided_with_init(capsys):
     expected_message = "The 'project name' parameter is missing with --init" \
                        "\n\nusage: 1build --init project_name"
     assert expected_message in captured.out
+
+
+@patch('os.path.isfile')
+def test_error_message_if_file_already_exists(mock_isfile):
+    mock_file_writer = MagicMock()
+
+    mock_isfile.return_value = True
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+
+    with patch("onebuild.init_command.write",
+               mock_file_writer,
+               create=True):
+        run("", ['--init', 'some project'])
+
+    sys.stdout = sys.__stdout__
+    assert "1build.yaml configuration file already exists." \
+           in captured_output.getvalue()
+
+    mock_file_writer.assert_not_called()


### PR DESCRIPTION
## Description

Do not override `1build.yaml` if already exists in --init command

## Fixes/Implements: #103 

## Checklist:

- [ ] My code follows the [style guidelines – pep8](https://www.python.org/dev/peps/pep-0008/) of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the [changelog draft](https://github.com/gopinath-langote/1build/blob/master/docs/CHANGELOG.md) for corresponding release
- [ ] I have update README (If needed)
