### PR TITLE
Execute multiple 1build command at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@
 
 <br>
 
-1build is an automation tool that arms you with the convenience to configure project-local command line aliases – and then 
-run the commands quickly and easily. It is particularly helpful when you deal with multiple projects and switch between 
-them all the time. It is often the fact that different projects use different build tools and have different environment 
-requirements – and then switching from one project to another is becoming increasingly cumbersome. That is where 1build comes 
+1build is an automation tool that arms you with the convenience to configure project-local command line aliases – and then
+run the commands quickly and easily. It is particularly helpful when you deal with multiple projects and switch between
+them all the time. It is often the fact that different projects use different build tools and have different environment
+requirements – and then switching from one project to another is becoming increasingly cumbersome. That is where 1build comes
 into play.
 
-With 1build you can create simple and easily memorable command aliases for commonly used project commands such as build, 
-test, run or anything else. These aliases will have a project-local scope which means that they will be accessible only 
-within the project directory. This way you can unify all your projects to build with the same simple command disregarding 
-of what build tool they use. It will remove the hassle of remembering all those commands improving the mental focus for 
+With 1build you can create simple and easily memorable command aliases for commonly used project commands such as build,
+test, run or anything else. These aliases will have a project-local scope which means that they will be accessible only
+within the project directory. This way you can unify all your projects to build with the same simple command disregarding
+of what build tool they use. It will remove the hassle of remembering all those commands improving the mental focus for
 the things that actually matter.
 
 ## Install
@@ -76,15 +76,15 @@ pip3 install 1build
   1build build
   ```
 
-- fix the coding guidelinges lint
+- fix the coding guidelinges lint and run tests (executing more than one commands at once)
   ```console
-  1build lint
+  1build lint test
   ```
 
 ### Using `before` and `after` commands
-Consider that your project `X` requires `Java 11` and the other project requires `Java 8`. It is a headache to always 
-remember to switch the java version. What you want is to switch to `Java 11` automatically when you build the project 
-`X` and switch it back to `Java 8` when the build is complete. Another example – a project requires `Docker` to be up 
+Consider that your project `X` requires `Java 11` and the other project requires `Java 8`. It is a headache to always
+remember to switch the java version. What you want is to switch to `Java 11` automatically when you build the project
+`X` and switch it back to `Java 8` when the build is complete. Another example – a project requires `Docker` to be up
 and running or you need to clean up the database after running a test harness.
 
 This is where `before` & `after` commands are useful. These commands are both optional – 
@@ -105,7 +105,7 @@ you can use one of them, both or neither.
     project: Containerized Project
     before: ./docker_run.sh
     commands:
-      - build: ./gradlew clean 
+      - build: ./gradlew clean
     ```
 
 3. Clean up database after some commands
@@ -113,7 +113,7 @@ you can use one of them, both or neither.
     project: Containerized Project
     after: ./clean_database.sh
     commands:
-      - build: ./gradlew clean 
+      - build: ./gradlew clean
     ```
 
 ### Command usage
@@ -136,7 +136,7 @@ Please read [CONTRIBUTING.md](https://github.com/gopinath-langote/1build/blob/ma
 
 ## Versioning
 
-We use [Semantic Versioning](http://semver.org/) for all our releases. For the versions available, see the [tags on this repository](https://github.com/gopinath-langote/1build/tags). 
+We use [Semantic Versioning](http://semver.org/) for all our releases. For the versions available, see the [tags on this repository](https://github.com/gopinath-langote/1build/tags).
 
 ## Changelog
 All notable changes to this project in each release will be documented in [CHANGELOG.md](https://github.com/gopinath-langote/1build/blob/master/docs/CHANGELOG.md).
@@ -153,4 +153,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 * **Alexander Lukianchuk** - *Maintainer* – [Github](https://github.com/landpro) – [Twitter](https://twitter.com/landpro)
 
 See also the list of [contributors](https://github.com/gopinath-langote/1build/contributors) who participated in this project.
-

--- a/onebuild/action_to_command_lookup.py
+++ b/onebuild/action_to_command_lookup.py
@@ -13,7 +13,9 @@ class ActionToCommandLookup:
             PredefinedActions.HELP: HelpCommand(),
             PredefinedActions.INIT: InitCommand(),
             PredefinedActions.LIST: ListCommand(),
-            PredefinedActions.VERSION: VersionCommand()})
+            PredefinedActions.VERSION: VersionCommand(),
+            PredefinedActions.PERFORM: PerformCommand()
+        })
 
     def get_command_for_action(self, action):
         return self._command_to_action_dictionary.get(action, PerformCommand())

--- a/onebuild/input_parser.py
+++ b/onebuild/input_parser.py
@@ -9,9 +9,8 @@ def argument_parser():
     parser = argparse.ArgumentParser(prog='1build', add_help=False)
     parser.add_argument(
         'command',
-        nargs='?',
-        default=PredefinedActions.HELP,
-        help='Command to run - from `1build.yaml` file',
+        nargs='*',
+        help='Command(s) to run - from `1build.yaml` file',
     )
     parser.add_argument(
         '-h', '--help',
@@ -51,5 +50,7 @@ def command_to_run(arg_parser, arguments):
         return PredefinedActions.INIT
     if args.list:
         return PredefinedActions.LIST
+    if len(args.command) == 0:
+        return PredefinedActions.HELP
 
-    return args.command
+    return PredefinedActions.PERFORM

--- a/onebuild/perform_command.py
+++ b/onebuild/perform_command.py
@@ -9,10 +9,17 @@ class PerformCommand(Command):
 
     def execute(self, arg_parser, arguments, build_file_name, command_name):
         project = parse_project_config(build_file_name)
+        args = arg_parser.parse_args(args=arguments)
+        for cmd in args.command:
+            self.__execute_command__(project, cmd)
+
+    @staticmethod
+    def __execute_command__(project, command_name):
         command = project.get_command(command_name)
 
         cmd = command.cmd
-        print(DASH + "\nName: " + command.name + "\nCommand: " + command.cmd)
+        print(DASH + "\nName: " + command.name +
+              "\nCommand: " + command.cmd)
 
         before = project.before
         after = project.after

--- a/onebuild/predefined_actions.py
+++ b/onebuild/predefined_actions.py
@@ -3,3 +3,4 @@ class PredefinedActions:
     HELP = "ONEBUILD_HELP"
     LIST = "ONEBUILD_LIST"
     INIT = "ONEBUILD_INIT"
+    PERFORM = "ONEBUILD_PERFROM"

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -2,10 +2,11 @@
 
 from onebuild.main import run
 
-USAGE_HELP_MESSAGE = """usage: 1build [-h] [-l] [-v] [-i] [command]
+USAGE_HELP_MESSAGE \
+    = """usage: 1build [-h] [-l] [-v] [-i] [command [command ...]]
 
 positional arguments:
-  command        Command to run - from `1build.yaml` file
+  command        Command(s) to run - from `1build.yaml` file
 
 optional arguments:
   -h, --help     Print this help message

--- a/tests/test_perform_command.py
+++ b/tests/test_perform_command.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from onebuild.main import run
+from .test_utils import DASH
+
+
+def test_build_successful_command(capsys):
+    run("tests/data/build_file.yaml", ['build'])
+    captured = capsys.readouterr()
+    expected_message = "" + DASH + "\n" \
+                                   "Name: build\n" \
+                                   "Command: echo 'Running build'\n" \
+                       + DASH + "\n"
+    assert expected_message in captured.out
+
+
+def test_multiple_commands_successful(capsys):
+    run("tests/data/build_file.yaml", ['build', 'lint'])
+    captured = capsys.readouterr()
+    expected_build_cmd_message = \
+        "" + DASH + "\n" \
+                    "Name: build\n" \
+                    "Command: echo 'Running build'\n" \
+        + DASH + "\n"
+    expected_lint_cmd_message = \
+        "" + DASH + "\n" \
+                    "Name: lint\n" \
+                    "Command: echo 'Running lint'\n" \
+        + DASH + "\n"
+    assert expected_build_cmd_message in captured.out
+    assert expected_lint_cmd_message in captured.out


### PR DESCRIPTION
Issue: #102

## Description

Imagine you want to execute two or more commands at one time.

ex
`1build build test`
`1build lint test`

With this feature, you can run that one after other.

## Fixes/Implements: #102 

## New dependencies introduced?


## Checklist:

- [x] My code follows the [style guidelines – pep8](https://www.python.org/dev/peps/pep-0008/) of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [changelog draft](https://github.com/gopinath-langote/1build/blob/master/docs/CHANGELOG.md) for corresponding release
- [x] I have update README (If needed)
