### PR TITLE
Implements functionality to unset multiple commands in one call

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ the things that actually matter.
    1build unset lint
    ```
 
+- To unset multiple commands at once
+  ```console
+  1build unset lint test build
+  ```
+
 ### Using `before` and `after` commands
 Consider that your project requires some environment variables to set before running any 
 commands and you want to clean up those after running commands. It is a headache to always

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -12,14 +12,14 @@ import (
 
 var unsetCmd = &cobra.Command{
 	Use:   "unset",
-	Short: "Remove the existing command in the current project configuration",
-	Long: `Remove the existing command in the current project configuration
+	Short: "Remove one or more existing command(s) in the current project configuration",
+	Long: `Remove one or more existing command(s) in the current project configuration
 
 - command name is a one word: without spaces, dashes and underscores are allowed
 
 For example:
 
-  1build unset test
+  1build unset test build
 
 This will update the current project configuration file.`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/gopinath-langote/1build/cmd/config"
 	"github.com/gopinath-langote/1build/cmd/utils"
@@ -44,13 +45,20 @@ This will update the current project configuration file.`,
 			return
 		}
 
+		var commandsNotFound []string
+
 		for _, commandName := range args {
 			index := indexOfCommandIfPresent(configuration, commandName)
 			if index == -1 {
-				utils.Println("Command '" + commandName + "' not found")
+				commandsNotFound = append(commandsNotFound, commandName)
 			} else {
 				configuration.Commands = removeCommandByIndex(configuration, index)
 			}
+		}
+
+		if len(commandsNotFound) != 0 {
+			errorMsg := "Following command(s) not found: " + strings.Join(commandsNotFound, ", ")
+			utils.PrintlnErr(errorMsg)
 		}
 
 		_ = config.WriteConfigFile(configuration)

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -21,7 +21,7 @@ For example:
   1build unset test
 
 This will update the current project configuration file.`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MinimumNArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_, err := config.LoadOneBuildConfiguration()
 		if err != nil {
@@ -38,21 +38,21 @@ This will update the current project configuration file.`,
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		commandName := args[0]
-
 		configuration, err := config.LoadOneBuildConfiguration()
 		if err != nil {
 			utils.PrintErr(err)
 			return
 		}
 
-		index := indexOfCommandIfPresent(configuration, commandName)
-		if index == -1 {
-			utils.Println("Command '" + commandName + "' not found")
-			return
+		for _, commandName := range args {
+			index := indexOfCommandIfPresent(configuration, commandName)
+			if index == -1 {
+				utils.Println("Command '" + commandName + "' not found")
+			} else {
+				configuration.Commands = removeCommandByIndex(configuration, index)
+			}
 		}
 
-		configuration.Commands = removeCommandByIndex(configuration, index)
 		_ = config.WriteConfigFile(configuration)
 	},
 }

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -19,7 +19,8 @@ var unsetCmd = &cobra.Command{
 
 For example:
 
-  1build unset test build
+  1build unset test
+  1build unset build lint other-command
 
 This will update the current project configuration file.`,
 	Args: cobra.MinimumNArgs(1),

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -46,6 +46,7 @@ This will update the current project configuration file.`,
 		}
 
 		var commandsNotFound []string
+		var configIsChanged bool
 
 		for _, commandName := range args {
 			index := indexOfCommandIfPresent(configuration, commandName)
@@ -53,6 +54,7 @@ This will update the current project configuration file.`,
 				commandsNotFound = append(commandsNotFound, commandName)
 			} else {
 				configuration.Commands = removeCommandByIndex(configuration, index)
+				configIsChanged = true
 			}
 		}
 
@@ -61,7 +63,9 @@ This will update the current project configuration file.`,
 			utils.PrintlnErr(errorMsg)
 		}
 
-		_ = config.WriteConfigFile(configuration)
+		if configIsChanged {
+			_ = config.WriteConfigFile(configuration)
+		}
 	},
 }
 

--- a/testing/fixtures/command_unset_fixtures.go
+++ b/testing/fixtures/command_unset_fixtures.go
@@ -17,7 +17,8 @@ func featureUnsetTestsData() []Test {
 		unsetShouldFailWhenConfigurationFileIsInInvalidFormat(feature),
 		unsetShouldFailWhenCommandIsNotFound(feature),
 		shouldUnsetMultipleCommands(feature),
-		shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound(feature),
+		shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound1(feature),
+		shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound2(feature),
 	}
 }
 
@@ -65,7 +66,7 @@ commands:
 			return utils.CreateConfigFile(dir, defaultFileContent)
 		},
 		Assertion: func(dir string, actualOutput string, t *testing.T) bool {
-			return assert.Contains(t, actualOutput, "Command 'Test' not found")
+			return assert.Contains(t, actualOutput, "Following command(s) not found: Test")
 		},
 	}
 }
@@ -124,7 +125,7 @@ commands: []
 	}
 }
 
-func shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound(feature string) Test {
+func shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound1(feature string) Test {
 
 	defaultFileContent := `
 project: Sample Project
@@ -139,7 +140,7 @@ commands: []
 
 	return Test{
 		Feature: feature,
-		Name:    "shouldUnsetMultipleCommands",
+		Name:    "shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound1",
 		CmdArgs: []string{"unset", "build", "test", "missingCmd"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, defaultFileContent)
@@ -149,7 +150,42 @@ commands: []
 			assert.FileExists(t, dir+"/"+def.ConfigFileName)
 			content, _ := ioutil.ReadFile(filePath)
 
-			testResult := assert.Contains(t, actualOutput, "Command 'missingCmd' not found") &&
+			testResult := assert.Contains(t, actualOutput, "Following command(s) not found: missingCmd") &&
+				assert.Exactly(t, expectedOutput, string(content))
+
+			return testResult
+		},
+	}
+}
+
+func shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound2(feature string) Test {
+
+	defaultFileContent := `
+project: Sample Project
+commands:
+  - build: go build
+  - test: go test
+  - lint: go lint
+`
+
+	expectedOutput := `project: Sample Project
+commands:
+  - lint: go lint
+`
+
+	return Test{
+		Feature: feature,
+		Name:    "shouldUnsetMultipleCommandsEvenWhenCommandIsNotFound2",
+		CmdArgs: []string{"unset", "build", "missingCmd", "test", "missingCmd2"},
+		Setup: func(dir string) error {
+			return utils.CreateConfigFile(dir, defaultFileContent)
+		},
+		Assertion: func(dir string, actualOutput string, t *testing.T) bool {
+			filePath := dir + "/" + def.ConfigFileName
+			assert.FileExists(t, dir+"/"+def.ConfigFileName)
+			content, _ := ioutil.ReadFile(filePath)
+
+			testResult := assert.Contains(t, actualOutput, "Following command(s) not found: missingCmd, missingCmd2") &&
 				assert.Exactly(t, expectedOutput, string(content))
 
 			return testResult


### PR DESCRIPTION
## Description

This PR implements the functionality to unset multiple commands in a single call.

Any failures encountered during the process will be printed but does not stop the operation.

## Fixes/Implements: # (issue)
#141 

## New dependencies introduced?
N.A.

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [changelog draft](https://github.com/gopinath-langote/1build/blob/master/docs/CHANGELOG.md) for corresponding release
- [x] I have update README (If needed)
