### PR TITLE
Add phase banners to the tops of each phase

### DIFF
--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -41,6 +41,7 @@ func ExecutePlan(commands ...string) {
 }
 
 func executeAndStopIfFailed(command *models.CommandContext) {
+	command.PrintBanner()
 	err := command.CommandSession.Run()
 	if err != nil {
 		exitCode := (err.Error())[12:]

--- a/cmd/models/onebuild-execution-plan.go
+++ b/cmd/models/onebuild-execution-plan.go
@@ -2,11 +2,13 @@ package models
 
 import (
 	"fmt"
-	"github.com/codeskyblue/go-sh"
-	"github.com/gopinath-langote/1build/cmd/utils"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/codeskyblue/go-sh"
+	"github.com/gopinath-langote/1build/cmd/utils"
+	"github.com/logrusorgru/aurora"
 )
 
 // OneBuildExecutionPlan holds all information for the execution strategy
@@ -22,6 +24,13 @@ type CommandContext struct {
 	Command        string
 	CommandSession *sh.Session
 }
+
+const (
+	commandBannerLength = 72
+
+	bannerOpen  = "[ "
+	bannerClose = " ]"
+)
 
 // HasBefore return true if plan contains before section else false
 func (executionPlan *OneBuildExecutionPlan) HasBefore() bool {
@@ -89,4 +98,28 @@ func longestPhaseAndCommandValue(executionPlan *OneBuildExecutionPlan) (string, 
 
 func dashesOfLength(text string) string {
 	return strings.Repeat("-", len(text))
+}
+
+// PrintBanner prints the CommandContext's name in a 72-character banner
+func (c *CommandContext) PrintBanner() {
+	centreLength := len(c.Name) + len(bannerOpen) + len(bannerClose)
+	totalDashes := commandBannerLength - centreLength
+
+	// Intentional integer division
+	numDashesLeft := totalDashes / 2
+	numDashesRight := totalDashes / 2
+
+	// If we need an extra dash, let's add it on the right.
+	// This way, similar length aliases will line up
+	if totalDashes%2 == 1 {
+		numDashesRight++
+	}
+
+	fmt.Printf("%s%s%s%s%s\n",
+		strings.Repeat("-", numDashesLeft),
+		bannerOpen,
+		aurora.BrightCyan(c.Name),
+		bannerClose,
+		strings.Repeat("-", numDashesRight),
+	)
 }

--- a/cmd/models/onebuild-execution-plan.go
+++ b/cmd/models/onebuild-execution-plan.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"unicode/utf8"
 
 	"github.com/codeskyblue/go-sh"
 	"github.com/gopinath-langote/1build/cmd/utils"
@@ -100,7 +101,9 @@ func dashesOfLength(text string) string {
 
 // PrintBanner prints the CommandContext's name in a banner of the standard length
 func (c *CommandContext) PrintBanner() {
-	centreLength := len(c.Name) + len(bannerOpen) + len(bannerClose)
+	centreLength := utf8.RuneCountInString(c.Name) +
+		utf8.RuneCountInString(bannerOpen) +
+		utf8.RuneCountInString(bannerClose)
 	totalDashes := utils.MaxOutputWidth - centreLength
 
 	// Intentional integer division

--- a/cmd/models/onebuild-execution-plan.go
+++ b/cmd/models/onebuild-execution-plan.go
@@ -26,8 +26,6 @@ type CommandContext struct {
 }
 
 const (
-	commandBannerLength = 72
-
 	bannerOpen  = "[ "
 	bannerClose = " ]"
 )
@@ -100,10 +98,10 @@ func dashesOfLength(text string) string {
 	return strings.Repeat("-", len(text))
 }
 
-// PrintBanner prints the CommandContext's name in a 72-character banner
+// PrintBanner prints the CommandContext's name in a banner of the standard length
 func (c *CommandContext) PrintBanner() {
 	centreLength := len(c.Name) + len(bannerOpen) + len(bannerClose)
-	totalDashes := commandBannerLength - centreLength
+	totalDashes := utils.MaxOutputWidth - centreLength
 
 	// Intentional integer division
 	numDashesLeft := totalDashes / 2

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 )
 
+const (
+	// MaxOutputWidth is the number of spaces to use on a console
+	MaxOutputWidth = 72
+)
+
 // Exit exits the current process with specified exit code
 func Exit(code int) {
 	os.Exit(code)

--- a/testing/fixtures/execute_cmd_fixtures.go
+++ b/testing/fixtures/execute_cmd_fixtures.go
@@ -35,6 +35,7 @@ Phase    Command
 build    echo building project
 
 
+-------------------------------[ ` + aurora.BrightCyan("build").String() + ` ]--------------------------------
 building project
 
 ` + aurora.BrightGreen("SUCCESS").Bold().String() + `
@@ -94,7 +95,9 @@ before    echo running pre-command
 build     echo building project
 
 
+-------------------------------[ ` + aurora.BrightCyan("before").String() + ` ]-------------------------------
 running pre-command
+-------------------------------[ ` + aurora.BrightCyan("build").String() + ` ]--------------------------------
 building project
 
 ` + aurora.BrightGreen("SUCCESS").Bold().String() + `
@@ -127,7 +130,9 @@ build    echo building project
 after    echo running post-command
 
 
+-------------------------------[ ` + aurora.BrightCyan("build").String() + ` ]--------------------------------
 building project
+-------------------------------[ ` + aurora.BrightCyan("after").String() + ` ]--------------------------------
 running post-command
 
 ` + aurora.BrightGreen("SUCCESS").Bold().String() + `
@@ -162,8 +167,11 @@ build     echo building project
 after     echo running post-command
 
 
+-------------------------------[ ` + aurora.BrightCyan("before").String() + ` ]-------------------------------
 running pre-command
+-------------------------------[ ` + aurora.BrightCyan("build").String() + ` ]--------------------------------
 building project
+-------------------------------[ ` + aurora.BrightCyan("after").String() + ` ]--------------------------------
 running post-command
 
 ` + aurora.BrightGreen("SUCCESS").Bold().String() + `
@@ -198,6 +206,7 @@ build     echo building project
 after     echo running post-command
 
 
+-------------------------------[ ` + aurora.BrightCyan("before").String() + ` ]-------------------------------
 
 -----------------------------------------------------------------------------------------------------------
 ` + aurora.Red("Execution failed during phase \"before\" - Execution of the script \"exit 10\" returned non-zero exit code : 10").Bold().String() + `
@@ -233,7 +242,9 @@ build     invalid_command
 after     echo running post-command
 
 
+-------------------------------[ ` + aurora.BrightCyan("before").String() + ` ]-------------------------------
 running pre-command
+-------------------------------[ ` + aurora.BrightCyan("build").String() + ` ]--------------------------------
 
 -------------------------------------------------------------------------------------------------------------------
 ` + aurora.Red("Execution failed during phase \"build\" - Execution of the script \"invalid_command\" returned non-zero exit code : 127").Bold().String() + `


### PR DESCRIPTION
## Description

This adds banners to the tops of each phase. This makes it easier to follow the flow in a multi-phase alias.

## Fixes/Implements: https://github.com/gopinath-langote/1build/issues/154

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have update README (If needed)


## Notes to reviewer
This prints the banner unconditionally, whether it is a command, a before, or an after. This also prints the banner even if the command fails. I personally think this constantness is a good thing, allowing a user to see exactly what happened during execution (and exactly which step failed), but I will gladly change it if desired.