### PR TITLE
Dockerfile to build alpine based base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.12 AS builder
+
+RUN mkdir -p /app
+WORKDIR /app
+
+ENV GO111MODULE=on
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY . .
+RUN go install ./...
+
+FROM alpine:latest
+
+WORKDIR /root/
+
+RUN apk add --no-cache \
+        libc6-compat
+
+COPY --from=builder /go/bin/1build /usr/bin/1build


### PR DESCRIPTION
## Description

Dockerfile to build alpine based docker base image. Projects using 1build can use this as base image.

## Fixes/Implements: #63 

## New dependencies introduced?
N/A

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have update README (If needed)
