### PR TITLE
Fix checking for invalid names used in unset

### DIFF
--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -32,7 +32,7 @@ This will update the current project configuration file.`,
 			utils.ExitError()
 		}
 
-		validNameRegex, _ := regexp.Compile(`^[a-zA-Z0-9\-_]+$`)
+		validNameRegex := regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 		for _, commandName := range args {
 			matched := validNameRegex.MatchString(commandName)
 

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -32,12 +32,13 @@ This will update the current project configuration file.`,
 			utils.ExitError()
 		}
 
-		commandName := args[0]
-		matched, _ := regexp.MatchString(`^[a-zA-Z0-9\-_]+$`, commandName)
+		for _, commandName := range args {
+			matched, _ := regexp.MatchString(`^[a-zA-Z0-9\-_]+$`, commandName)
 
-		if !matched {
-			fmt.Println("1build unset: '" + commandName + "' is not a valid command name. See '1build unset --help'.")
-			utils.ExitError()
+			if !matched {
+				fmt.Println("1build unset: '" + commandName + "' is not a valid command name. See '1build unset --help'.")
+				utils.ExitError()
+			}
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -32,8 +32,9 @@ This will update the current project configuration file.`,
 			utils.ExitError()
 		}
 
+		validNameRegex, _ := regexp.Compile(`^[a-zA-Z0-9\-_]+$`)
 		for _, commandName := range args {
-			matched, _ := regexp.MatchString(`^[a-zA-Z0-9\-_]+$`, commandName)
+			matched := validNameRegex.MatchString(commandName)
 
 			if !matched {
 				fmt.Println("1build unset: '" + commandName + "' is not a valid command name. See '1build unset --help'.")

--- a/testing/fixtures/command_unset_fixtures.go
+++ b/testing/fixtures/command_unset_fixtures.go
@@ -1,11 +1,12 @@
 package fixtures
 
 import (
+	"io/ioutil"
+	"testing"
+
 	"github.com/gopinath-langote/1build/testing/def"
 	"github.com/gopinath-langote/1build/testing/utils"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
-	"testing"
 )
 
 func featureUnsetTestsData() []Test {
@@ -24,6 +25,8 @@ func featureUnsetTestsData() []Test {
 		shouldUnsetTheAfterCommand(feature),
 		unsetBeforeShouldFailWhenBeforeIsNotFound(feature),
 		unsetAfterShouldFailWhenAfterIsNotFound(feature),
+		unsetSingleCommandShouldFailWhenInvalidCommandNameIsEntered(feature),
+		unsetMultipleCommandShouldFailWhenInvalidCommandNameIsEntered(feature),
 	}
 }
 
@@ -326,6 +329,50 @@ commands:
 		},
 		Assertion: func(dir string, actualOutput string, t *testing.T) bool {
 			return assert.Contains(t, actualOutput, "Following command(s) not found: after")
+		},
+	}
+}
+
+func unsetSingleCommandShouldFailWhenInvalidCommandNameIsEntered(feature string) Test {
+	defaultFileContent := `
+project: Sample Project
+commands:
+  - build: go build
+`
+	invalidName := "!nv@lid-name"
+	expectedOutput := "1build unset: '" + invalidName + "' is not a valid command name. See '1build unset --help'."
+
+	return Test{
+		Feature: feature,
+		Name:    "unsetSingleCommandShouldFailWhenInvalidCommandNameIsEntered",
+		CmdArgs: []string{"unset", invalidName},
+		Setup: func(dir string) error {
+			return utils.CreateConfigFile(dir, defaultFileContent)
+		},
+		Assertion: func(dir string, actualOutput string, t *testing.T) bool {
+			return assert.Contains(t, actualOutput, expectedOutput)
+		},
+	}
+}
+
+func unsetMultipleCommandShouldFailWhenInvalidCommandNameIsEntered(feature string) Test {
+	defaultFileContent := `
+project: Sample Project
+commands:
+  - build: go build
+`
+	invalidName := "!nv@lid-name"
+	expectedOutput := "1build unset: '" + invalidName + "' is not a valid command name. See '1build unset --help'."
+
+	return Test{
+		Feature: feature,
+		Name:    "unsetSingleCommandShouldFailWhenInvalidCommandNameIsEntered",
+		CmdArgs: []string{"unset", "build", invalidName},
+		Setup: func(dir string) error {
+			return utils.CreateConfigFile(dir, defaultFileContent)
+		},
+		Assertion: func(dir string, actualOutput string, t *testing.T) bool {
+			return assert.Contains(t, actualOutput, expectedOutput)
 		},
 	}
 }


### PR DESCRIPTION
## Description
This PR fixes the way invalid command names are checked in `unset`. The existing implementation only checks the first command name, this PR makes sure all commands passed to `unset` are checked.

## Fixes/Implements: # (issue)
Handle invalid command names passed to `unset` command

## If New dependencies introduced
None

## Checklist
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have update README (If needed)
