### PR TITLE
Feat/run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ brew install gopinath-langote/one-build/one-build
 
 -   building the project
 ```console
-  1build build
+  1build run build
   ```
 
 -   fix the coding guidelines lint and run tests (executing more than one commands at once)
 ```console
-  1build lint test
+  1build run lint test
   ```
 
 ### Set new or update existing configuration
@@ -114,9 +114,9 @@ you can use one of them, both or neither.
     1build set before 'export VARNAME="my value"'
     1build set after "unset VARNAME"
     ```
-  
+
     Configuration with before and after setup
-    
+
     ```yaml
     project: Sample Web App
     before: export VARNAME="my value"
@@ -145,11 +145,11 @@ Sometimes you choose to not see all logs/output of your command and just see suc
 So using `--quiet` or `-q` flag to 1build command execution will result in just executing the command
 but not showing the entire output of it, only shows SUCCESS/FAILURE as result of command execution.
 ```console
-  1build lint test --quiet
+  1build run lint test --quiet
   ```
   OR
 ```console
-  1build lint test -q
+  1build run lint test -q
   ```
 
 See `1build --help` for command usages.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	parse "github.com/gopinath-langote/1build/cmd/config"
-	"github.com/gopinath-langote/1build/cmd/exec"
 	"github.com/gopinath-langote/1build/cmd/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,13 +21,15 @@ var rootCmd = &cobra.Command{
 			utils.ExitError()
 		}
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			listCmd.Run(cmd, args)
-		} else {
-			exec.ExecutePlan(args...)
-		}
-	},
+	/*
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				listCmd.Run(cmd, args)
+			} else {
+				exec.ExecutePlan(args...)
+			}
+		},
+	*/
 }
 
 // Execute entry-point for cobra app

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,15 +21,10 @@ var rootCmd = &cobra.Command{
 			utils.ExitError()
 		}
 	},
-	/*
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 1 {
-				listCmd.Run(cmd, args)
-			} else {
-				exec.ExecutePlan(args...)
-			}
-		},
-	*/
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Please specify a command to 1build")
+		cmd.Help()
+	},
 }
 
 // Execute entry-point for cobra app

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gopinath-langote/1build/cmd/config"
+	"github.com/gopinath-langote/1build/cmd/exec"
+	"github.com/gopinath-langote/1build/cmd/utils"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run [command..]",
+	Short: "Run command(s) from the current project configuration",
+	Long:  "Run command(s) from the current project configuration",
+	Args:  cobra.MinimumNArgs(0),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		_, err := config.LoadOneBuildConfiguration()
+		if err != nil {
+			fmt.Println(err)
+			utils.ExitError()
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			listCmd.Run(cmd, args)
+		} else {
+			exec.ExecutePlan(args...)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}

--- a/testing/fixtures/command_list_fixtures.go
+++ b/testing/fixtures/command_list_fixtures.go
@@ -1,9 +1,10 @@
 package fixtures
 
 import (
+	"testing"
+
 	"github.com/gopinath-langote/1build/testing/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func featureListTestData() []Test {
@@ -50,7 +51,7 @@ commands:
 	return Test{
 		Feature: feature,
 		Name:    "shouldNotShowAnyCommandsIfNoCommandsFound",
-		CmdArgs: []string{},
+		CmdArgs: []string{"run"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, "project: Sample Project\ncommands:\n")
 		},

--- a/testing/fixtures/command_root_fixtures.go
+++ b/testing/fixtures/command_root_fixtures.go
@@ -1,10 +1,11 @@
 package fixtures
 
 import (
+	"testing"
+
 	"github.com/gopinath-langote/1build/testing/def"
 	"github.com/gopinath-langote/1build/testing/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func featureRootTestData() []Test {
@@ -13,7 +14,7 @@ func featureRootTestData() []Test {
 	return []Test{
 		shouldFailIfYamlFileIsNotPresent(feature),
 		shouldFailIfYamlFileIsNotInCorrectYamlFormat(feature),
-		shouldShowListOfCommandsIfNoCommandSpecified(feature),
+		shouldShowHelpMessageIfNoCommandSpecified(feature),
 	}
 }
 
@@ -53,14 +54,8 @@ commands:
 	}
 }
 
-func shouldShowListOfCommandsIfNoCommandSpecified(feature string) Test {
-	commandListMessage := `------------------------------------------------------------------------
-project: Sample Project
-commands:
-build | npm run build
-lint | eslint
-------------------------------------------------------------------------
-`
+func shouldShowHelpMessageIfNoCommandSpecified(feature string) Test {
+	commandListMessage := `Please specify a command to 1build`
 	defaultFileContent := `
 project: Sample Project
 commands:

--- a/testing/fixtures/execute_cmd_fixtures.go
+++ b/testing/fixtures/execute_cmd_fixtures.go
@@ -40,7 +40,7 @@ building project
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteAvailableCommand",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -68,7 +68,7 @@ build | echo building project
 	return Test{
 		Feature: feature,
 		Name:    "shouldShowErrorIfCommandNotFound",
-		CmdArgs: []string{"random"},
+		CmdArgs: []string{"run", "random"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -102,7 +102,7 @@ building project
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteBeforeCommand",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -137,7 +137,7 @@ running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteAfterCommand",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -176,7 +176,7 @@ running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteBeforeAndAfterCommand",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -209,7 +209,7 @@ after     echo running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldStopExecutionIfBeforeCommandFailed",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -246,7 +246,7 @@ running pre-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldStopExecutionIfCommandFailed",
-		CmdArgs: []string{"build"},
+		CmdArgs: []string{"run", "build"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},

--- a/testing/fixtures/flag_fixtures.go
+++ b/testing/fixtures/flag_fixtures.go
@@ -37,7 +37,7 @@ build    echo building project
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteCommandWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -70,7 +70,7 @@ build     echo building project
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteBeforeCommandWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -103,7 +103,7 @@ after    echo running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteAfterCommandWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -139,7 +139,7 @@ after     echo running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldExecuteBeforeAndAfterCommandWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -174,7 +174,7 @@ after     echo running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldStopExecutionIfBeforeCommandFailedWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},
@@ -211,7 +211,7 @@ after     echo running post-command
 	return Test{
 		Feature: feature,
 		Name:    "shouldStopExecutionIfCommandFailedWithquietFlag",
-		CmdArgs: []string{"build", "--quiet"},
+		CmdArgs: []string{"run", "build", "--quiet"},
 		Setup: func(dir string) error {
 			return utils.CreateConfigFile(dir, fileContent)
 		},


### PR DESCRIPTION
## Description

This PR introduces the `run` keyword that will be used to execute user defined commands. This fundamentally changes the way 1build is used. 

The previous implementation treats all non-reserved arguments as user defined commands, whereas now the `run` keyword has to be explicitly provided before 1build treats it as a user defined command.

The motivation for this feature can be found in the issue link.

## Fixes/Implements: # (issue)
#179 

## If New dependencies introduced
N.A

## Checklist

-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have update README (If needed)
